### PR TITLE
TTL any cleaned up or newly added keys

### DIFF
--- a/spec/congestion/rate_limiter_spec.rb
+++ b/spec/congestion/rate_limiter_spec.rb
@@ -81,6 +81,20 @@ describe Congestion::RateLimiter do
         .with limiter.key, time, time
       subject
     end
+
+    it 'should set the ttl on the key if it is not set' do
+      expect(limiter.redis).to receive(:pexpire).with(limiter.key, limiter.options[:interval]) # the interval
+      subject
+    end
+
+    it 'should not set the ttl on the key if already set' do
+      limiter.redis.multi do |t|
+        t.zadd limiter.key, 1, 1
+        t.pexpire limiter.key, limiter.options[:interval]
+      end
+      expect(limiter.redis).not_to receive(:pexpire)
+      subject
+    end
   end
 
   describe '#get_requests' do


### PR DESCRIPTION
We've been experiencing large RAM use in redis due to congestion keys without TTLs. 

We've identified 2 scenarios this can occur: 
1. when a key is newly added but never run through the limiter again to have the TTL set.
0. the `zremrangebyscore` cleans up all old set entries, removes the key and pexpire on a missing key doesn't add a TTL.

This PR ensures all keys set by congestion will have an associated TTL no matter if the limiter runs again and we avoid the redis RAM use bloat.
